### PR TITLE
add ENV proxy support

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -6,6 +6,7 @@ const https = require('https');
 const mkdirp = require('mkdirp');
 const parse = require('url').parse;
 const lookup = require('dns').lookup;
+const HttpsProxyAgent = require('https-proxy-agent');
 
 const HOME = require('os').homedir();
 const DIR = path.join(HOME, '.gittar');
@@ -14,7 +15,15 @@ const strip = (a, b, c) => a.replace(b, '').replace(c, '');
 
 function download(uri, file) {
 	return new Promise((res, rej) => {
-		https.get(uri, r => {
+		const https_proxy = process.env.https_proxy || process.env.HTTPS_PROXY;
+		const http_proxy = process.env.http_proxy || process.env.HTTP_PROXY;
+		let obj = parse(uri);
+		if (https_proxy) {
+			obj.agent = new HttpsProxyAgent(Object.assign(parse(https_proxy), { secureProxy: true }));
+		} else if (http_proxy) {
+			obj.agent = new HttpsProxyAgent(http_proxy);
+		}
+		https.get(obj, r => {
 			const code = r.statusCode;
 			if (code >= 400) return rej({ code, message:r.statusMessage });
 			if (code > 300 && code < 400) return download(r.headers.location, file).then(res);

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "tarball"
   ],
   "dependencies": {
+    "https-proxy-agent": "^2.1.1",
     "mkdirp": "^0.5.1",
     "tar": "^3.1.9"
   },


### PR DESCRIPTION
Use proxy to download repo archives, when ENV `https_proxy` `HTTPS_PROXY` or `http_proxy` `HTTP_PROXY` is set.