### PR TITLE
 Add support for user-specifiable name for cache directory

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -35,8 +35,8 @@ function getHint(str) {
 	return arr && arr[1];
 }
 
-function getTarFile(obj) {
-	return path.join(DIR, obj.site, obj.repo, `${obj.type}.tar.gz`);
+function getTarFile(obj, name) {
+	return path.join(name !== undefined ? path.join(HOME, '.' + name) : DIR, obj.site, obj.repo, `${obj.type}.tar.gz`);
 }
 
 function getTarUrl(obj) {
@@ -58,10 +58,10 @@ function parser(uri, host) {
 	return { site, repo, type };
 }
 
-function exists(file) {
+function exists(file, name) {
 	// file is a `user/repo#tag`
 	if (!path.isAbsolute(file)) {
-		file = getTarFile( parser(file) );
+		file = getTarFile(parser(file), name);
 	}
 	return fs.existsSync(file) && file;
 }
@@ -77,10 +77,10 @@ function run(arr) {
 exports.fetch = function (repo, opts) {
 	opts = opts || {};
 	const info = parser(repo, opts.host);
-	const file = getTarFile(info);
+	const file = getTarFile(info, opts.name);
 	const uri = getTarUrl(info);
 
-	const local = _ => Promise.resolve( exists(file) );
+	const local = _ => Promise.resolve(exists(file, opts.name));
 	const remote = _ => download(uri, file);
 
 	return new Promise((res, rej) => {
@@ -100,11 +100,12 @@ exports.fetch = function (repo, opts) {
 }
 
 exports.extract = function (file, dest, opts) {
-	file = exists(file);
+  opts = opts || {};
+	file = exists(file, opts.name);
 	dest = path.resolve(dest || '.');
 	return new Promise((res, rej) => {
 		const ok = _ => res(dest);
-		opts = Object.assign({ strip:1 }, opts, { file, cwd:dest });
+		opts = Object.assign({ strip:1 }, opts, { file, cwd:dest, name: undefined });
 		return file ? mkdirp(dest, err => err ? rej(err) : tar.extract(opts).then(ok).catch(rej)) : rej();
 	});
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -36,7 +36,8 @@ function getHint(str) {
 }
 
 function getTarFile(obj, name) {
-	return path.join(name !== undefined ? path.join(HOME, '.' + name) : DIR, obj.site, obj.repo, `${obj.type}.tar.gz`);
+  const dir = name ? path.join(HOME, `.${name}`) : DIR;
+  return path.join(dir, obj.site, obj.repo, `${obj.type}.tar.gz`);
 }
 
 function getTarUrl(obj) {
@@ -105,7 +106,7 @@ exports.extract = function (file, dest, opts) {
 	dest = path.resolve(dest || '.');
 	return new Promise((res, rej) => {
 		const ok = _ => res(dest);
-		opts = Object.assign({ strip:1 }, opts, { file, cwd:dest, name: undefined });
+		opts = Object.assign({ strip:1, name:null }, opts, { file, cwd:dest });
 		return file ? mkdirp(dest, err => err ? rej(err) : tar.extract(opts).then(ok).catch(rej)) : rej();
 	});
 }

--- a/readme.md
+++ b/readme.md
@@ -153,7 +153,7 @@ The name of gittar's cache directory.
 
 ```js
 gittar.fetch('herber/cargo', { name: 'custom' }).then(console.log);
-//=> ~/.custom/github/lukeed/gittar/master.tar.gz
+//=> ~/.custom/github/herber/cargo/master.tar.gz
 ```
 
 ### gittar.extract(file, target, options)
@@ -208,7 +208,7 @@ The name of gittar's cache directory.
 ```js
 gittar.extract('herber/cargo#master', 'foo', { name: 'custom' });
 // Searches in ~/.custom/ for the tarball
-//=> contents: foo/mri-master/**
+//=> contents: foo/cargo-master/**
 ```
 
 ## License

--- a/readme.md
+++ b/readme.md
@@ -145,6 +145,16 @@ Only attempt to use an existing, cached file. No network requests will be dispat
 
 > **Note:** Gittar enacts this option if it detects that there is no internet connectivity.
 
+#### options.dirname
+Type: `String`<br>
+Default: `gittar`
+
+The name of gittar's cache directory.
+
+```js
+gittar.fetch('herber/cargo', { name: 'custom' }).then(console.log);
+//=> ~/.custom/github/lukeed/gittar/master.tar.gz
+```
 
 ### gittar.extract(file, target, options)
 
@@ -189,6 +199,17 @@ gittar.extract(file, 'foo', { strip:0 });
 //=> contents: foo/mri-master/**
 ```
 
+#### options.name
+Type: `String`<br>
+Default: `gittar`
+
+The name of gittar's cache directory.
+
+```js
+gittar.extract('herber/cargo#master', 'foo', { name: 'custom' });
+// Searches in ~/.custom/ for the tarball
+//=> contents: foo/mri-master/**
+```
 
 ## License
 


### PR DESCRIPTION
Users should be able to choose the name of gittar's directory in `~/`.

Instead of `.gittar` users can choose any name.

### Example
#### gittar.fetch

```js
gittar.fetch('lukeed/polka', { name: 'custom' }).then(console.log);
//=> ~/.custom/github/lukeed/polka/master.tar.gz
```

#### gittar.extract

```js
gittar.extract('lukeed/polka#master', 'foo', { name: 'custom' });
// Searches in ~/.custom/ for the tarball
//=> contents: foo/polka-master/**
```
