### PR TITLE
Fix 404 error when calling with full URL

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -10,7 +10,7 @@ const lookup = require('dns').lookup;
 const HOME = require('os').homedir();
 const DIR = path.join(HOME, '.gittar');
 
-const strip = (a, b, c) => a.replace(b, '').replace(c, '');
+const strip = (a, b, c, d) => a.replace(b, '').replace(c, '').replace(d, '');
 
 function download(uri, file) {
 	return new Promise((res, rej) => {
@@ -31,8 +31,8 @@ function writer(file) {
 }
 
 function getHint(str) {
-	const arr = str.match(/^(git(hub|lab)|bitbucket):/i);
-	return arr && arr[1];
+	const arr = str.match(/^(https:\/\/)?(git(hub|lab)|bitbucket)(:)?/i);
+	return arr && arr[2];
 }
 
 function getTarFile(obj) {
@@ -53,7 +53,7 @@ function getTarUrl(obj) {
 function parser(uri, host) {
 	const info = parse(uri);
 	const site = getHint(uri) || host || 'github';
-	const repo = strip(uri, info.protocol, info.hash);
+	const repo = strip(uri, info.protocol, info.hash,`//${site}.com`);
 	const type = (info.hash || '#master').substr(1);
 	return { site, repo, type };
 }
@@ -79,7 +79,6 @@ exports.fetch = function (repo, opts) {
 	const info = parser(repo, opts.host);
 	const file = getTarFile(info);
 	const uri = getTarUrl(info);
-
 	const local = _ => Promise.resolve( exists(file) );
 	const remote = _ => download(uri, file);
 

--- a/test/index.js
+++ b/test/index.js
@@ -49,6 +49,36 @@ test('gittar.fetch (user/repo#tag)', t => {
 	});
 });
 
+test('gittar.fetch with full github link', t => {
+	t.plan(6);
+	const isOk = validate(t);
+	const repo = 'https://github.com/lukeed/mri';
+	fn.fetch(repo).then(isOk).then(foo => {
+		t.true( foo.includes('github'), 'parses `github` hostname' );
+		t.true( foo.includes('master'), 'grabs `master` archive' );
+		// will grab same file
+		fn.fetch(repo, { host:'github' }).then(isOk).then(cleanup).then(bar => {
+			t.pass('accepts `host` object');
+			t.equal(foo, bar, 'resolves same repo/file path');
+		});
+	});
+});
+
+test('gittar.fetch with full gitlab link', t => {
+	t.plan(6);
+	const isOk = validate(t);
+	const repo = 'https://gitlab.com/Rich-Harris/buble';
+	fn.fetch(repo).then(isOk).then(foo => {
+		t.true( foo.includes('gitlab'), 'parses `gitlab` hostname' );
+		t.true( foo.includes('master'), 'grabs `master` archive' );
+		// will grab same file
+		fn.fetch(repo, { host:'gitlab' }).then(isOk).then(cleanup).then(bar => {
+			t.pass('accepts `host` object');
+			t.equal(foo, bar, 'resolves same repo/file path');
+		});
+	});
+});
+
 test('gittar.fetch (host:user/repo#tag)', t => {
 	t.plan(6);
 	const isOk = validate(t);


### PR DESCRIPTION
Fix a 404 when calling 
`gittar.fetch('https://github.com/lukeed/mri').then(console.log);` where the URL would be constructed incorrectly (`https://github.com///github.com/lukeed/mri/archive/master.tar.gz`) due to the hostname already existing 